### PR TITLE
fix go.mod: モジュールネーム修正(ごめんなさい)

### DIFF
--- a/cluster-game-server/go.mod
+++ b/cluster-game-server/go.mod
@@ -1,3 +1,3 @@
-module app
+module github.com/CA22-game-creators/cookingbomb-gameserver
 
 go 1.16


### PR DESCRIPTION
## Issues
#3 

## About
指摘された修正点の修正忘れを修正
#4 
> [IMO]
> Goでは一般的にmodule名はrepositoryのルートを使う事が多いから
> 
> module github.com/CA22-game-creators/cookingbomb-gameserver
> 
> の方がしっくりくるかも！(長いけど)

## Background
None

## Details
go.modの修正

## Remarks
None

## Preview
None