### PR TITLE
Update/connection handling

### DIFF
--- a/cluster-game-server/application/connect/interactor.go
+++ b/cluster-game-server/application/connect/interactor.go
@@ -23,11 +23,11 @@ func (i interactor) Handle(input InputData) OutputData {
 		return OutputData{Err: err}
 	}
 
-	if i.repository.GetStatus(input.SessionToken) == domain.CONNECTED {
+	if i.repository.CheckSessionActive(input.SessionToken) {
 		return OutputData{Err: errors.New("already connected")}
 	}
 
 	i.repository.Connect(input.SessionToken)
 
-	return OutputData{Status: i.repository.GetStatus(input.SessionToken)}
+	return OutputData{Status: i.repository.GetSessionStatus(input.SessionToken)}
 }

--- a/cluster-game-server/application/connect/interactor.go
+++ b/cluster-game-server/application/connect/interactor.go
@@ -22,7 +22,7 @@ func (i interactor) Handle(input InputData) OutputData {
 		return OutputData{Err: err}
 	}
 
-	if i.repository.CheckSessionActive(input.SessionToken) {
+	if status := i.repository.GetSessionStatus(input.SessionToken); !status.IsConnectable() {
 		return OutputData{Err: errors.InvalidOperation()}
 	}
 

--- a/cluster-game-server/application/connect/interactor.go
+++ b/cluster-game-server/application/connect/interactor.go
@@ -1,9 +1,8 @@
 package application
 
 import (
-	"errors"
-
 	domain "github.com/CA22-game-creators/cookingbomb-gameserver/cluster-game-server/domain/model/account"
+	"github.com/CA22-game-creators/cookingbomb-gameserver/cluster-game-server/errors"
 )
 
 type interactor struct {
@@ -24,7 +23,7 @@ func (i interactor) Handle(input InputData) OutputData {
 	}
 
 	if i.repository.CheckSessionActive(input.SessionToken) {
-		return OutputData{Err: errors.New("already connected")}
+		return OutputData{Err: errors.InvalidOperation()}
 	}
 
 	i.repository.Connect(input.SessionToken)

--- a/cluster-game-server/application/disconnect/interactor.go
+++ b/cluster-game-server/application/disconnect/interactor.go
@@ -17,7 +17,7 @@ func New(r domain.Repository) InputPort {
 
 func (i interactor) Handle(input InputData) OutputData {
 
-	if i.repository.CheckSessionActive(input.SessionToken) {
+	if !i.repository.CheckSessionActive(input.SessionToken) {
 		return OutputData{Err: errors.SessionNotActive()}
 	}
 

--- a/cluster-game-server/application/disconnect/interactor.go
+++ b/cluster-game-server/application/disconnect/interactor.go
@@ -17,11 +17,11 @@ func New(r domain.Repository) InputPort {
 
 func (i interactor) Handle(input InputData) OutputData {
 
-	if i.repository.GetStatus(input.SessionToken) != domain.CONNECTED {
+	if i.repository.CheckSessionActive(input.SessionToken) {
 		return OutputData{Err: errors.SessionNotActive()}
 	}
 
 	i.repository.Disconnect(input.SessionToken)
 
-	return OutputData{Status: i.repository.GetStatus(input.SessionToken)}
+	return OutputData{Status: i.repository.GetSessionStatus(input.SessionToken)}
 }

--- a/cluster-game-server/application/disconnect/interactor.go
+++ b/cluster-game-server/application/disconnect/interactor.go
@@ -17,7 +17,7 @@ func New(r domain.Repository) InputPort {
 
 func (i interactor) Handle(input InputData) OutputData {
 
-	if !i.repository.CheckSessionActive(input.SessionToken) {
+	if status := i.repository.GetSessionStatus(input.SessionToken); !status.IsActive() {
 		return OutputData{Err: errors.SessionNotActive()}
 	}
 

--- a/cluster-game-server/application/get_connection_status/interactor.go
+++ b/cluster-game-server/application/get_connection_status/interactor.go
@@ -16,6 +16,6 @@ func New(r domain.Repository) InputPort {
 
 func (i interactor) Handle(input InputData) OutputData {
 	return OutputData{
-		Status: i.repository.GetStatus(input.SessionToken),
+		Status: i.repository.GetSessionStatus(input.SessionToken),
 	}
 }

--- a/cluster-game-server/domain/model/account/repository.go
+++ b/cluster-game-server/domain/model/account/repository.go
@@ -3,7 +3,8 @@ package domain
 
 type Repository interface {
 	Find(sessionToken string) (Account, error)
-	GetStatus(sessionToken string) StatusEnum
+	GetSessionStatus(sessionToken string) StatusEnum
+	CheckSessionActive(sessionToken string) bool
 	Connect(sessionToken string)
 	Disconnect(sessionToken string)
 }

--- a/cluster-game-server/domain/model/account/repository.go
+++ b/cluster-game-server/domain/model/account/repository.go
@@ -4,7 +4,6 @@ package domain
 type Repository interface {
 	Find(sessionToken string) (Account, error)
 	GetSessionStatus(sessionToken string) StatusEnum
-	CheckSessionActive(sessionToken string) bool
 	Connect(sessionToken string)
 	Disconnect(sessionToken string)
 }

--- a/cluster-game-server/domain/model/account/status.go
+++ b/cluster-game-server/domain/model/account/status.go
@@ -7,3 +7,21 @@ const (
 	CONNECTED
 	DISCONNECTED_BY_CLIENT
 )
+
+func (s StatusEnum) IsConnectable() bool {
+	switch s {
+	case CONNECTED:
+		return false
+	default:
+		return true
+	}
+}
+
+func (s StatusEnum) IsActive() bool {
+	switch s {
+	case CONNECTED:
+		return true
+	default:
+		return false
+	}
+}

--- a/cluster-game-server/errors/errors.go
+++ b/cluster-game-server/errors/errors.go
@@ -5,8 +5,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func AuthAPIThrowError() error {
-	return status.Error(codes.Unauthenticated, "Auth API Rejected Session Token")
+func AuthAPIThrowError(v string) error {
+	return status.Errorf(codes.Unauthenticated, "Auth API Rejected Session Token: %s", v)
 }
 
 func SessionNotActive() error {

--- a/cluster-game-server/infrastructure/repository/impl.go
+++ b/cluster-game-server/infrastructure/repository/impl.go
@@ -62,14 +62,6 @@ func (i impl) GetSessionStatus(sessionToken string) domain.StatusEnum {
 	return status.(domain.StatusEnum)
 }
 
-func (i impl) CheckSessionActive(sessionToken string) bool {
-	status, ok := i.instance.Get(sessionToken)
-	if !ok {
-		return false
-	}
-	return status == domain.CONNECTED
-}
-
 func (i impl) Connect(sessionToken string) {
 	i.instance.Set(sessionToken, domain.CONNECTED, goCache.NoExpiration)
 }

--- a/cluster-game-server/infrastructure/repository/impl.go
+++ b/cluster-game-server/infrastructure/repository/impl.go
@@ -75,5 +75,5 @@ func (i impl) Connect(sessionToken string) {
 }
 
 func (i impl) Disconnect(sessionToken string) {
-	i.instance.Set(sessionToken, domain.DISCONNECTED_BY_CLIENT, goCache.NoExpiration)
+	i.instance.Set(sessionToken, domain.DISCONNECTED_BY_CLIENT, goCache.DefaultExpiration)
 }

--- a/cluster-game-server/infrastructure/repository/impl.go
+++ b/cluster-game-server/infrastructure/repository/impl.go
@@ -55,12 +55,20 @@ func (i impl) Find(sesisonToken string) (domain.Account, error) {
 	), nil
 }
 
-func (i impl) GetStatus(sessionToken string) domain.StatusEnum {
+func (i impl) GetSessionStatus(sessionToken string) domain.StatusEnum {
 	status, ok := i.instance.Get(sessionToken)
 	if !ok {
 		return domain.UNSPECIFIED
 	}
 	return status.(domain.StatusEnum)
+}
+
+func (i impl) CheckSessionActive(sessionToken string) bool {
+	status, ok := i.instance.Get(sessionToken)
+	if !ok {
+		return false
+	}
+	return status == domain.CONNECTED
 }
 
 func (i impl) Connect(sessionToken string) {

--- a/cluster-game-server/infrastructure/repository/impl.go
+++ b/cluster-game-server/infrastructure/repository/impl.go
@@ -45,8 +45,7 @@ func (i impl) Find(sesisonToken string) (domain.Account, error) {
 	req := &pb.GetAccountInfoRequest{SessionToken: sesisonToken}
 	res, err := client.GetAccountInfo(ctx, req)
 	if err != nil || res.GetAccountInfo() == nil {
-		log.Print("API Server Returned Error: ", err)
-		return domain.Account{}, errors.AuthAPIThrowError()
+		return domain.Account{}, errors.AuthAPIThrowError(err.Error())
 	}
 
 	return domain.FromRepository(


### PR DESCRIPTION
## Issues
None
## About
- セッションの有効性確認を一般化 & メソッド変更
  -  CheckSessionActiveの実装
  -  GetStatus->GetSessionStatusにrename
- APIThrowErrorのエラー文に文字列を添付するよう変更
  -  認証時のエラー文を返却するよう変更
- Disconnect処理時のキャッシュの有効期限を変更
  -  無期限だったものを、DefaultExpirationに変更(30分)
- Disconnect時のセッションの有効性確認のバグを修正
  -  セッションが有効だった時に「SessionNotActive」を返していた
- Connectのすでにセッションが有効なときに返すエラーを変更
  -  errors.new -> errors.InvalidOperation